### PR TITLE
feat: add Prometheus metrics and OpenTelemetry tracing for observability

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,3 +43,49 @@ RATE_LIMIT_CLEANUP_INTERVAL=300            # Cleanup interval for old entries in
 - **Development**: `RATE_LIMIT_PER_MINUTE=300` (higher limit for testing)
 - **Production**: `RATE_LIMIT_PER_MINUTE=60` (balanced protection)
 - **Strict**: `RATE_LIMIT_PER_MINUTE=30` (high-security environments)
+
+## Observability
+
+The API ships with Prometheus metrics and OpenTelemetry tracing.
+
+### Enable or disable
+
+```bash
+ENABLE_METRICS=true
+ENABLE_TRACING=true
+OTEL_SERVICE_NAME=rag-researcher
+OTEL_EXPORTER_TYPE=jaeger   # jaeger | otlp | console
+JAEGER_ENDPOINT=http://localhost:14268/api/traces
+OTEL_TRACE_SAMPLE_RATE=1.0
+METRICS_SLOW_QUERY_THRESHOLD_MS=100
+```
+
+### Metrics endpoint
+
+- Prometheus scrape: `GET /metrics`
+- Health check includes observability flags: `GET /health`
+
+### Tracing (Jaeger)
+
+- Jaeger UI: `http://localhost:16686`
+- Collector endpoint: `http://localhost:14268/api/traces`
+
+### Key metrics
+
+- `http_request_duration_seconds`: API latency percentiles (p50/p95/p99)
+- `rag_query_duration_seconds`: End-to-end RAG latency
+- `rag_retrieval_duration_seconds`: Vector search duration
+- `rag_generation_duration_seconds`: LLM response time
+- `embedding_generation_duration_seconds`: Embedding latency
+- `cache_operations_total{result="hit"}`: Cache hit rate
+- `database_query_duration_seconds`: Database query performance
+- `active_requests`: Current in-flight requests
+- `ingestion_jobs_total{status="success"}`: Ingestion success rate
+
+### Example Prometheus queries
+
+- API request rate: `rate(http_requests_total[5m])`
+- API error rate: `rate(http_requests_total{status_code=~"5.."}[5m])`
+- RAG p95 latency: `histogram_quantile(0.95, rate(rag_query_duration_seconds_bucket[5m]))`
+- Cache hit rate: `rate(cache_operations_total{result="hit"}[5m]) / rate(cache_operations_total[5m])`
+- Slow DB queries: `rate(database_query_duration_seconds_bucket{le="0.1"}[5m])`

--- a/app/applications/ingestion_application.py
+++ b/app/applications/ingestion_application.py
@@ -1,6 +1,7 @@
 """Application-level orchestration for ingestion workflows."""
 
 import hashlib
+import time
 from typing import Any, Literal
 
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -20,6 +21,12 @@ from app.rag.chunking import (
     chunk_pdf_extraction,
     chunk_youtube_extraction,
 )
+from app.observability.metrics import (
+    record_database_query,
+    record_embedding,
+    record_ingestion_job,
+)
+from app.observability.tracing import add_span_event, trace_context_manager
 from app.services.exceptions import (
     EmbeddingError,
     IngestionError,
@@ -134,6 +141,7 @@ class IngestionApplicationService:
             ValueError: If source_type is unsupported.
         """
         logger.info("Starting ingestion", source=source, source_type=source_type)
+        start_time = time.perf_counter()
 
         # Update source status to processing
         await self.source_service.update_source_status(
@@ -141,125 +149,169 @@ class IngestionApplicationService:
         )
 
         try:
-            # Extract content
-            try:
-                if source_type == "pdf":
-                    extraction = extract_from_pdf(source)
-                elif source_type == "youtube":
-                    extraction = extract_from_youtube(source)
-                else:
-                    raise ValueError(f"Unsupported source_type: {source_type}")
-            except (PDFExtractionError, YouTubeExtractionError) as exc:
-                raise IngestionError(
-                    message=f"Failed to extract content from {source_type} source",
-                    stage="extraction",
-                    source_id=source_id,
-                    **get_request_context_data(),
-                ) from exc
+            with trace_context_manager(
+                "ingestion.process_source",
+                {
+                    "source_id": source_id,
+                    "source_type": source_type,
+                    "collection_name": collection_name,
+                },
+            ):
+                # Extract content
+                try:
+                    with trace_context_manager(
+                        "ingestion.extract",
+                        {"source_type": source_type},
+                    ):
+                        if source_type == "pdf":
+                            extraction = extract_from_pdf(source)
+                        elif source_type == "youtube":
+                            extraction = extract_from_youtube(source)
+                        else:
+                            raise ValueError(f"Unsupported source_type: {source_type}")
+                except (PDFExtractionError, YouTubeExtractionError) as exc:
+                    raise IngestionError(
+                        message=f"Failed to extract content from {source_type} source",
+                        stage="extraction",
+                        source_id=source_id,
+                        **get_request_context_data(),
+                    ) from exc
 
-            # Merge metadata
-            base_metadata = extraction.get("metadata", {})
-            if extra_metadata:
-                base_metadata = {**base_metadata, **extra_metadata}
+                # Merge metadata
+                base_metadata = extraction.get("metadata", {})
+                if extra_metadata:
+                    base_metadata = {**base_metadata, **extra_metadata}
 
-            if source_uuid:
-                base_metadata["source_uuid"] = source_uuid
-            if source_key:
-                base_metadata["source_key"] = source_key
+                if source_uuid:
+                    base_metadata["source_uuid"] = source_uuid
+                if source_key:
+                    base_metadata["source_key"] = source_key
 
-            extraction["metadata"] = base_metadata
+                extraction["metadata"] = base_metadata
 
-            file_hash = self._compute_file_hash_from_extraction(extraction)
+                file_hash = self._compute_file_hash_from_extraction(extraction)
+                add_span_event("content_hash_computed", {"source_id": source_id})
 
-            # Smart re-ingest logic
-            existing_hash = await get_existing_file_hash(self.db, source_id)
-            if existing_hash and existing_hash == file_hash:
-                logger.info("Source unchanged; skipping ingestion", source_id=source_id)
+                # Smart re-ingest logic
+                existing_hash = await get_existing_file_hash(self.db, source_id)
+                if existing_hash and existing_hash == file_hash:
+                    logger.info("Source unchanged; skipping ingestion", source_id=source_id)
+                    add_span_event("duplicate_detected", {"source_id": source_id})
+                    await self.source_service.update_source_status(
+                        source_id, schemas.SourceStatus.ready
+                    )
+                    record_ingestion_job(
+                        source_type=source_type,
+                        status="skipped",
+                        duration_seconds=time.perf_counter() - start_time,
+                        chunks_count=0,
+                    )
+                    return {
+                        "chunks_added": 0,
+                        "collection": collection_name,
+                        "ids": [],
+                        "content_hash": file_hash,
+                        "status": "skipped",
+                    }
+
+                if existing_hash and existing_hash != file_hash:
+                    deleted = await delete_chunks_by_source(self.db, source_id)
+                    logger.info(
+                        "Source modified; re-ingesting",
+                        source_id=source_id,
+                        deleted_chunks=deleted,
+                    )
+
+                # Chunk content
+                try:
+                    with trace_context_manager("ingestion.chunk"):
+                        chunks = self._prepare_chunks(extraction, source_id)
+                    add_span_event("chunks_prepared", {"chunks_count": len(chunks)})
+                except Exception as exc:
+                    raise IngestionError(
+                        message="Failed to chunk extracted content",
+                        stage="chunking",
+                        source_id=source_id,
+                        **get_request_context_data(),
+                    ) from exc
+
+                # Generate embeddings
+                embedder = HuggingFaceTEIEmbedder(
+                    base_url=settings.TEI_URL,
+                    max_batch_size=settings.TEI_MAX_BATCH,
+                    mode="passage",
+                )
+
+                texts = [c["text"] for c in chunks]
+                try:
+                    with trace_context_manager(
+                        "ingestion.embed",
+                        {"provider": "huggingface_tei", "mode": "passage"},
+                    ):
+                        embed_start = time.perf_counter()
+                        embeddings = await embedder.embed_documents(texts)
+                        embed_duration = time.perf_counter() - embed_start
+                        record_embedding(
+                            provider="huggingface_tei",
+                            mode="passage",
+                            duration_seconds=embed_duration,
+                            batch_size=len(texts),
+                        )
+                except Exception as exc:
+                    raise EmbeddingError(
+                        message="Failed to generate embeddings for document chunks",
+                        provider="huggingface_tei",
+                        **get_request_context_data(),
+                    ) from exc
+
+                content_hash = self._compute_content_hash(texts, source_type)
+
+                # Insert chunks
+                try:
+                    with trace_context_manager("ingestion.store"):
+                        store_start = time.perf_counter()
+                        inserted = await insert_chunks(
+                            self.db,
+                            chunks=chunks,
+                            embeddings=embeddings,
+                            source_id=source_id,
+                            file_hash=file_hash,
+                            collection_name=collection_name,
+                        )
+                        store_duration = time.perf_counter() - store_start
+                        record_database_query("INSERT", "document_chunks", store_duration)
+                except Exception as exc:
+                    raise VectorStoreError(
+                        message="Failed to insert chunks into vector store",
+                        operation="insert",
+                        **get_request_context_data(),
+                    ) from exc
+
+                logger.info(
+                    "Ingestion completed",
+                    chunks_added=inserted,
+                    collection=collection_name,
+                )
+
+                # Update source status and metadata
                 await self.source_service.update_source_status(
                     source_id, schemas.SourceStatus.ready
                 )
+
+                record_ingestion_job(
+                    source_type=source_type,
+                    status="success",
+                    duration_seconds=time.perf_counter() - start_time,
+                    chunks_count=inserted,
+                )
+
                 return {
-                    "chunks_added": 0,
+                    "chunks_added": inserted,
                     "collection": collection_name,
-                    "ids": [],
-                    "content_hash": file_hash,
-                    "status": "skipped",
+                    "ids": [c["id"] for c in chunks],
+                    "content_hash": content_hash,
+                    "status": "ingested",
                 }
-
-            if existing_hash and existing_hash != file_hash:
-                deleted = await delete_chunks_by_source(self.db, source_id)
-                logger.info(
-                    "Source modified; re-ingesting",
-                    source_id=source_id,
-                    deleted_chunks=deleted,
-                )
-
-            # Chunk content
-            try:
-                chunks = self._prepare_chunks(extraction, source_id)
-            except Exception as exc:
-                raise IngestionError(
-                    message="Failed to chunk extracted content",
-                    stage="chunking",
-                    source_id=source_id,
-                    **get_request_context_data(),
-                ) from exc
-
-            # Generate embeddings
-            embedder = HuggingFaceTEIEmbedder(
-                base_url=settings.TEI_URL,
-                max_batch_size=settings.TEI_MAX_BATCH,
-                mode="passage",
-            )
-
-            texts = [c["text"] for c in chunks]
-            # embed_documents is now async with built-in caching
-            try:
-                embeddings = await embedder.embed_documents(texts)
-            except Exception as exc:
-                raise EmbeddingError(
-                    message="Failed to generate embeddings for document chunks",
-                    provider="huggingface_tei",
-                    **get_request_context_data(),
-                ) from exc
-
-            content_hash = self._compute_content_hash(texts, source_type)
-
-            # Insert chunks
-            try:
-                inserted = await insert_chunks(
-                    self.db,
-                    chunks=chunks,
-                    embeddings=embeddings,
-                    source_id=source_id,
-                    file_hash=file_hash,
-                    collection_name=collection_name,
-                )
-            except Exception as exc:
-                raise VectorStoreError(
-                    message="Failed to insert chunks into vector store",
-                    operation="insert",
-                    **get_request_context_data(),
-                ) from exc
-
-            logger.info(
-                "Ingestion completed",
-                chunks_added=inserted,
-                collection=collection_name,
-            )
-
-            # Update source status and metadata
-            await self.source_service.update_source_status(
-                source_id, schemas.SourceStatus.ready
-            )
-
-            return {
-                "chunks_added": inserted,
-                "collection": collection_name,
-                "ids": [c["id"] for c in chunks],
-                "content_hash": content_hash,
-                "status": "ingested",
-            }
 
         except (IngestionError, EmbeddingError, VectorStoreError) as exc:
             logger.error(
@@ -271,6 +323,12 @@ class IngestionApplicationService:
             await self.source_service.update_source_status(
                 source_id, schemas.SourceStatus.failed
             )
+            record_ingestion_job(
+                source_type=source_type,
+                status="failure",
+                duration_seconds=time.perf_counter() - start_time,
+                chunks_count=0,
+            )
             raise
         except Exception as exc:
             logger.error(
@@ -281,6 +339,12 @@ class IngestionApplicationService:
             )
             await self.source_service.update_source_status(
                 source_id, schemas.SourceStatus.failed
+            )
+            record_ingestion_job(
+                source_type=source_type,
+                status="failure",
+                duration_seconds=time.perf_counter() - start_time,
+                chunks_count=0,
             )
             raise IngestionError(
                 message="Unexpected error during ingestion",

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -107,6 +107,24 @@ class Settings(BaseSettings):
     CACHE_TTL_LLM: int = int(os.getenv("CACHE_TTL_LLM", "1800"))
     CACHE_KEY_PREFIX: str = os.getenv("CACHE_KEY_PREFIX", "rag_cache")
 
+    # -------------------------
+    # Observability
+    # -------------------------
+    ENABLE_METRICS: bool = os.getenv("ENABLE_METRICS", "true").lower() == "true"
+    ENABLE_TRACING: bool = os.getenv("ENABLE_TRACING", "true").lower() == "true"
+    OTEL_SERVICE_NAME: str = os.getenv("OTEL_SERVICE_NAME", "rag-researcher")
+    OTEL_EXPORTER_TYPE: str = os.getenv("OTEL_EXPORTER_TYPE", "jaeger")
+    JAEGER_ENDPOINT: str = os.getenv(
+        "JAEGER_ENDPOINT",
+        "http://localhost:14268/api/traces",
+    )
+    OTEL_TRACE_SAMPLE_RATE: float = float(
+        os.getenv("OTEL_TRACE_SAMPLE_RATE", "1.0")
+    )
+    METRICS_SLOW_QUERY_THRESHOLD_MS: int = int(
+        os.getenv("METRICS_SLOW_QUERY_THRESHOLD_MS", "100")
+    )
+
     @property
     def REDIS_CONNECTION_URL(self) -> str:
         """Return the Redis connection URL.

--- a/app/core/lifespan.py
+++ b/app/core/lifespan.py
@@ -8,6 +8,7 @@ from app.cache.redis_cache import get_redis_client
 from app.core.config import settings
 from app.core.logging import configure_logging, get_logger
 from app.db.sessions import engine, init_engine
+from app.observability.tracing import configure_tracing, instrument_sqlalchemy, shutdown_tracing
 from app.utils.files import ensure_directory
 
 logger = get_logger(__name__)
@@ -23,6 +24,20 @@ async def lifespan(app: FastAPI):
     # Configure logging
     configure_logging(json_logs=False)  # Use colored console for development
     logger.info("Starting RAG Researcher API", version=settings.VERSION)
+
+    if settings.ENABLE_TRACING:
+        configure_tracing(
+            service_name=settings.OTEL_SERVICE_NAME,
+            jaeger_endpoint=settings.JAEGER_ENDPOINT,
+            enable_console_export=settings.OTEL_EXPORTER_TYPE == "console",
+            exporter_type=settings.OTEL_EXPORTER_TYPE,
+            sample_rate=settings.OTEL_TRACE_SAMPLE_RATE,
+        )
+        logger.info(
+            "Tracing enabled",
+            exporter=settings.OTEL_EXPORTER_TYPE,
+            sample_rate=settings.OTEL_TRACE_SAMPLE_RATE,
+        )
     
     # Initialize database
     init_engine(
@@ -31,6 +46,9 @@ async def lifespan(app: FastAPI):
         max_overflow=settings.DB_MAX_OVERFLOW,
     )
     logger.info("Database engine initialized", driver="asyncpg", backend="pgvector")
+
+    if settings.ENABLE_TRACING and engine is not None:
+        instrument_sqlalchemy(engine.sync_engine)
     
     # Initialize Redis cache
     if settings.REDIS_ENABLED:
@@ -70,5 +88,9 @@ async def lifespan(app: FastAPI):
     if engine:
         await engine.dispose()
         logger.info("Database connections closed")
+
+    if settings.ENABLE_TRACING:
+        shutdown_tracing()
+        logger.info("Tracing shutdown complete")
     
     logger.info("🛑 Shutdown complete")

--- a/app/core/logging.py
+++ b/app/core/logging.py
@@ -5,12 +5,23 @@ import sys
 from typing import Any
 
 import structlog
+from opentelemetry import trace
 from structlog.typing import EventDict
 
 
 def add_app_context(logger: Any, method_name: str, event_dict: EventDict) -> EventDict:
     """Add application context to log entries."""
     event_dict["app"] = "rag_researcher"
+    return event_dict
+
+
+def add_trace_context(logger: Any, method_name: str, event_dict: EventDict) -> EventDict:
+    """Add OpenTelemetry trace context to log entries."""
+    span = trace.get_current_span()
+    if span.is_recording():
+        ctx = span.get_span_context()
+        event_dict["trace_id"] = format(ctx.trace_id, "032x")
+        event_dict["span_id"] = format(ctx.span_id, "016x")
     return event_dict
 
 
@@ -37,6 +48,7 @@ def configure_logging(level: int = logging.INFO, json_logs: bool = True) -> None
         structlog.processors.TimeStamper(fmt="iso"),
         structlog.processors.StackInfoRenderer(),
         add_app_context,
+        add_trace_context,
     ]
 
     if json_logs:
@@ -68,6 +80,18 @@ def get_logger(name: str | None = None) -> structlog.stdlib.BoundLogger:
         Structured logger with bound context.
     """
     return structlog.get_logger(name)
+
+
+def bind_trace_context() -> None:
+    """Bind trace context into structlog contextvars."""
+    span = trace.get_current_span()
+    if not span.is_recording():
+        return
+    ctx = span.get_span_context()
+    structlog.contextvars.bind_contextvars(
+        trace_id=format(ctx.trace_id, "032x"),
+        span_id=format(ctx.span_id, "016x"),
+    )
 
 
 # RAG-specific logging helpers

--- a/app/db/sessions.py
+++ b/app/db/sessions.py
@@ -1,7 +1,13 @@
 """Database session management with async support."""
 
-from collections.abc import AsyncGenerator
+from __future__ import annotations
 
+from collections.abc import AsyncGenerator
+import re
+import time
+
+from sqlalchemy import event
+from sqlalchemy.engine import Engine
 from sqlalchemy.ext.asyncio import (
     AsyncEngine,
     AsyncSession,
@@ -9,9 +15,83 @@ from sqlalchemy.ext.asyncio import (
     create_async_engine,
 )
 
+from app.core.config import settings
+from app.core.logging import get_logger
+from app.observability.metrics import record_database_query, set_database_pool_metrics
+
+logger = get_logger(__name__)
+
 # Global async engine and session factory
 engine: AsyncEngine | None = None
 async_session_maker: async_sessionmaker[AsyncSession] | None = None
+
+
+def _extract_operation(statement: str) -> str:
+    match = re.match(r"^\s*(SELECT|INSERT|UPDATE|DELETE|CREATE|ALTER|DROP)", statement, re.I)
+    if match:
+        return match.group(1).upper()
+    return "UNKNOWN"
+
+
+def _extract_table(statement: str, operation: str) -> str:
+    if operation == "SELECT" or operation == "DELETE":
+        pattern = r"\bFROM\s+([\w\"\.]+)"
+    elif operation == "INSERT":
+        pattern = r"\bINTO\s+([\w\"\.]+)"
+    elif operation == "UPDATE":
+        pattern = r"\bUPDATE\s+([\w\"\.]+)"
+    else:
+        return "unknown"
+
+    match = re.search(pattern, statement, re.I)
+    if not match:
+        return "unknown"
+    return match.group(1).strip('"')
+
+
+def _register_query_metrics(sync_engine: Engine) -> None:
+    @event.listens_for(sync_engine, "before_cursor_execute")
+    def before_cursor_execute(
+        conn: Engine,
+        cursor: object,
+        statement: str,
+        parameters: object,
+        context: object,
+        executemany: bool,
+    ) -> None:
+        setattr(context, "_query_start_time", time.perf_counter())
+
+    @event.listens_for(sync_engine, "after_cursor_execute")
+    def after_cursor_execute(
+        conn: Engine,
+        cursor: object,
+        statement: str,
+        parameters: object,
+        context: object,
+        executemany: bool,
+    ) -> None:
+        start_time = getattr(context, "_query_start_time", None)
+        if start_time is None:
+            return
+        duration_seconds = time.perf_counter() - start_time
+        operation = _extract_operation(statement)
+        table = _extract_table(statement, operation)
+        record_database_query(operation, table, duration_seconds)
+
+        duration_ms = duration_seconds * 1000
+        if duration_ms >= settings.METRICS_SLOW_QUERY_THRESHOLD_MS:
+            logger.warning(
+                "Slow query detected",
+                operation=operation,
+                table=table,
+                duration_ms=round(duration_ms, 2),
+            )
+
+        try:
+            pool = sync_engine.pool
+            set_database_pool_metrics(pool.size(), pool.checkedout())
+        except Exception:
+            return
 
 
 def init_engine(database_url: str, pool_size: int = 20, max_overflow: int = 10) -> None:
@@ -39,6 +119,12 @@ def init_engine(database_url: str, pool_size: int = 20, max_overflow: int = 10) 
         autocommit=False,
         autoflush=False,
     )
+
+    _register_query_metrics(engine.sync_engine)
+    try:
+        set_database_pool_metrics(engine.sync_engine.pool.size(), 0)
+    except Exception:
+        return
 
 
 async def get_db() -> AsyncGenerator[AsyncSession, None]:

--- a/app/main.py
+++ b/app/main.py
@@ -1,8 +1,9 @@
 from typing import Annotated
 
-from fastapi import Depends, FastAPI, Query, Request, status
+from fastapi import Depends, FastAPI, Query, Request, Response, status
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
+from prometheus_client import CONTENT_TYPE_LATEST, generate_latest
 import structlog
 from app.api.deps import current_user
 from app.cache.invalidation import (
@@ -15,6 +16,9 @@ from app.core.lifespan import lifespan
 from app.api.router import api_router
 from app.db import schemas
 from app.middleware.request_context import RequestContextMiddleware
+from app.middleware.observability import ObservabilityMiddleware
+from app.observability.metrics import get_metrics_registry
+from app.observability.tracing import configure_tracing, instrument_fastapi
 from app.services.exceptions import (
     AuthenticationError,
     BaseApplicationError,
@@ -35,6 +39,19 @@ def create_app() -> FastAPI:
         lifespan=lifespan
     )
 
+    if settings.ENABLE_TRACING:
+        configure_tracing(
+            service_name=settings.OTEL_SERVICE_NAME,
+            jaeger_endpoint=settings.JAEGER_ENDPOINT,
+            enable_console_export=settings.OTEL_EXPORTER_TYPE == "console",
+            exporter_type=settings.OTEL_EXPORTER_TYPE,
+            sample_rate=settings.OTEL_TRACE_SAMPLE_RATE,
+        )
+        instrument_fastapi(app)
+
+    if settings.ENABLE_METRICS:
+        _ = get_metrics_registry()
+
     # -------------------------
     # Middleware
     # -------------------------
@@ -51,6 +68,9 @@ def create_app() -> FastAPI:
 
     # Request context middleware
     app.add_middleware(RequestContextMiddleware)
+
+    # Observability middleware
+    app.add_middleware(ObservabilityMiddleware)
 
     # -------------------------
     # Routes
@@ -189,7 +209,24 @@ def create_app() -> FastAPI:
     # -------------------------
     @app.get("/health", tags=["system"])
     def health():
-        return {"status": "ok"}
+        return {
+            "status": "ok",
+            "metrics_enabled": settings.ENABLE_METRICS,
+            "tracing_enabled": settings.ENABLE_TRACING,
+        }
+
+    @app.get("/metrics", tags=["system"])
+    async def metrics() -> Response:
+        """Prometheus metrics endpoint."""
+        if not settings.ENABLE_METRICS:
+            return JSONResponse(
+                status_code=status.HTTP_404_NOT_FOUND,
+                content={"detail": "Metrics collection is disabled"},
+            )
+        return Response(
+            content=generate_latest(get_metrics_registry()),
+            media_type=CONTENT_TYPE_LATEST,
+        )
 
     # -------------------------
     # Cache management

--- a/app/middleware/observability.py
+++ b/app/middleware/observability.py
@@ -1,0 +1,78 @@
+"""Observability middleware for metrics and tracing."""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+
+from fastapi import Request, Response
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.types import ASGIApp
+import structlog
+from opentelemetry.trace.status import Status, StatusCode
+
+from app.core.config import settings
+from app.core.logging import bind_trace_context
+from app.observability.metrics import active_requests, record_http_request
+from app.observability.tracing import get_tracer
+
+
+class ObservabilityMiddleware(BaseHTTPMiddleware):
+    """Attach metrics and tracing to incoming requests."""
+
+    def __init__(self, app: ASGIApp) -> None:
+        super().__init__(app)
+
+    async def dispatch(self, request: Request, call_next: Any) -> Response:
+        tracer = get_tracer(__name__)
+        method = request.method
+        path = request.url.path
+        start_time = time.perf_counter()
+        status_code = 500
+
+        if settings.ENABLE_METRICS:
+            active_requests.inc()
+
+        with tracer.start_as_current_span("http.request") as span:
+            span.set_attribute("http.method", method)
+            span.set_attribute("http.path", path)
+            request_id = getattr(request.state, "request_id", None)
+            if request_id:
+                span.set_attribute("request_id", request_id)
+
+            contextvars = structlog.contextvars.get_contextvars()
+            user_id = contextvars.get("user_id")
+            if user_id is not None:
+                span.set_attribute("user_id", user_id)
+
+            bind_trace_context()
+
+            try:
+                response = await call_next(request)
+                status_code = response.status_code
+                span.set_attribute("http.status_code", status_code)
+                return response
+            except Exception as exc:
+                span.record_exception(exc)
+                span.set_status(Status(StatusCode.ERROR, str(exc)))
+                span.set_attribute("http.status_code", status_code)
+                raise
+            finally:
+                duration_seconds = time.perf_counter() - start_time
+                if settings.ENABLE_METRICS:
+                    record_http_request(method, path, status_code, duration_seconds)
+                    active_requests.dec()
+
+                span_ctx = span.get_span_context()
+                if span_ctx and span_ctx.trace_id:
+                    request.state.trace_id = format(span_ctx.trace_id, "032x")
+                    request.state.span_id = format(span_ctx.span_id, "016x")
+
+                if "response" in locals():
+                    if span_ctx and span_ctx.trace_id:
+                        response.headers["X-Trace-ID"] = format(
+                            span_ctx.trace_id, "032x"
+                        )
+                        response.headers["X-Span-ID"] = format(
+                            span_ctx.span_id, "016x"
+                        )

--- a/app/observability/__init__.py
+++ b/app/observability/__init__.py
@@ -1,0 +1,1 @@
+"""Observability helpers for metrics and tracing."""

--- a/app/observability/metrics.py
+++ b/app/observability/metrics.py
@@ -1,0 +1,288 @@
+"""Prometheus metrics definitions and helpers."""
+
+from __future__ import annotations
+
+from prometheus_client import CollectorRegistry, Counter, Gauge, Histogram
+
+from app.core.config import settings
+
+_REGISTRY = CollectorRegistry()
+
+# -------------------------
+# Counters
+# -------------------------
+http_requests_total = Counter(
+    "http_requests_total",
+    "Total HTTP requests",
+    ["method", "path", "status_code"],
+    registry=_REGISTRY,
+)
+
+rag_queries_total = Counter(
+    "rag_queries_total",
+    "Total RAG queries",
+    ["collection_name", "status"],
+    registry=_REGISTRY,
+)
+
+ingestion_jobs_total = Counter(
+    "ingestion_jobs_total",
+    "Total ingestion jobs",
+    ["source_type", "status"],
+    registry=_REGISTRY,
+)
+
+cache_operations_total = Counter(
+    "cache_operations_total",
+    "Total cache operations",
+    ["operation", "cache_type", "result"],
+    registry=_REGISTRY,
+)
+
+database_queries_total = Counter(
+    "database_queries_total",
+    "Total database queries",
+    ["operation", "table"],
+    registry=_REGISTRY,
+)
+
+# -------------------------
+# Histograms
+# -------------------------
+http_request_duration_seconds = Histogram(
+    "http_request_duration_seconds",
+    "HTTP request duration in seconds",
+    ["method", "path"],
+    registry=_REGISTRY,
+)
+
+rag_query_duration_seconds = Histogram(
+    "rag_query_duration_seconds",
+    "End-to-end RAG query duration in seconds",
+    ["collection_name"],
+    registry=_REGISTRY,
+)
+
+rag_retrieval_duration_seconds = Histogram(
+    "rag_retrieval_duration_seconds",
+    "RAG retrieval duration in seconds",
+    ["collection_name"],
+    registry=_REGISTRY,
+)
+
+rag_generation_duration_seconds = Histogram(
+    "rag_generation_duration_seconds",
+    "RAG generation duration in seconds",
+    ["model"],
+    registry=_REGISTRY,
+)
+
+embedding_generation_duration_seconds = Histogram(
+    "embedding_generation_duration_seconds",
+    "Embedding generation duration in seconds",
+    ["provider", "mode"],
+    registry=_REGISTRY,
+)
+
+database_query_duration_seconds = Histogram(
+    "database_query_duration_seconds",
+    "Database query duration in seconds",
+    ["operation", "table"],
+    registry=_REGISTRY,
+)
+
+cache_operation_duration_seconds = Histogram(
+    "cache_operation_duration_seconds",
+    "Cache operation duration in seconds",
+    ["operation", "cache_type"],
+    registry=_REGISTRY,
+)
+
+# -------------------------
+# Gauges
+# -------------------------
+active_requests = Gauge(
+    "active_requests",
+    "Current in-flight HTTP requests",
+    registry=_REGISTRY,
+)
+
+database_pool_size = Gauge(
+    "database_pool_size",
+    "Configured database connection pool size",
+    registry=_REGISTRY,
+)
+
+database_pool_checked_out = Gauge(
+    "database_pool_checked_out",
+    "Database connections currently checked out",
+    registry=_REGISTRY,
+)
+
+
+def get_metrics_registry() -> CollectorRegistry:
+    """Return the Prometheus registry used by the application.
+
+    Returns:
+        CollectorRegistry: Prometheus registry instance.
+    """
+    return _REGISTRY
+
+
+def _metrics_enabled() -> bool:
+    return settings.ENABLE_METRICS
+
+
+def record_http_request(
+    method: str,
+    path: str,
+    status_code: int,
+    duration_seconds: float,
+) -> None:
+    """Record HTTP request metrics.
+
+    Args:
+        method: HTTP method.
+        path: Request path.
+        status_code: HTTP response status code.
+        duration_seconds: Duration in seconds.
+    """
+    if not _metrics_enabled():
+        return
+    http_requests_total.labels(
+        method=method,
+        path=path,
+        status_code=str(status_code),
+    ).inc()
+    http_request_duration_seconds.labels(method=method, path=path).observe(
+        duration_seconds
+    )
+
+
+def record_rag_query(
+    collection: str,
+    duration_seconds: float,
+    retrieval_seconds: float,
+    generation_seconds: float,
+    status: str,
+) -> None:
+    """Record RAG query metrics.
+
+    Args:
+        collection: Collection name.
+        duration_seconds: End-to-end duration in seconds.
+        retrieval_seconds: Retrieval duration in seconds.
+        generation_seconds: Generation duration in seconds.
+        status: Status label (success/failure).
+    """
+    if not _metrics_enabled():
+        return
+    rag_queries_total.labels(collection_name=collection, status=status).inc()
+    rag_query_duration_seconds.labels(collection_name=collection).observe(
+        duration_seconds
+    )
+    rag_retrieval_duration_seconds.labels(collection_name=collection).observe(
+        retrieval_seconds
+    )
+    rag_generation_duration_seconds.labels(model=settings.OLLAMA_MODEL).observe(
+        generation_seconds
+    )
+
+
+def record_ingestion_job(
+    source_type: str,
+    status: str,
+    duration_seconds: float,
+    chunks_count: int,
+) -> None:
+    """Record ingestion job metrics.
+
+    Args:
+        source_type: Source type (pdf/youtube).
+        status: Status label (success/failure/skipped).
+        duration_seconds: End-to-end duration in seconds.
+        chunks_count: Number of chunks processed.
+    """
+    if not _metrics_enabled():
+        return
+    _ = chunks_count
+    ingestion_jobs_total.labels(source_type=source_type, status=status).inc()
+
+
+def record_embedding(
+    provider: str,
+    mode: str,
+    duration_seconds: float,
+    batch_size: int,
+) -> None:
+    """Record embedding generation metrics.
+
+    Args:
+        provider: Embedding provider name.
+        mode: Embedding mode (query/passage).
+        duration_seconds: Duration in seconds.
+        batch_size: Size of the embedding batch.
+    """
+    if not _metrics_enabled():
+        return
+    _ = batch_size
+    embedding_generation_duration_seconds.labels(provider=provider, mode=mode).observe(
+        duration_seconds
+    )
+
+
+def record_cache_operation(
+    operation: str,
+    cache_type: str,
+    duration_seconds: float,
+    hit: bool,
+) -> None:
+    """Record cache operation metrics.
+
+    Args:
+        operation: Cache operation type.
+        cache_type: Cache type name.
+        duration_seconds: Duration in seconds.
+        hit: Whether the operation was a cache hit.
+    """
+    if not _metrics_enabled():
+        return
+    result = "hit" if hit else "miss"
+    cache_operations_total.labels(
+        operation=operation,
+        cache_type=cache_type,
+        result=result,
+    ).inc()
+    cache_operation_duration_seconds.labels(
+        operation=operation,
+        cache_type=cache_type,
+    ).observe(duration_seconds)
+
+
+def record_database_query(operation: str, table: str, duration_seconds: float) -> None:
+    """Record database query metrics.
+
+    Args:
+        operation: SQL operation (SELECT/INSERT/UPDATE/DELETE).
+        table: Table name.
+        duration_seconds: Duration in seconds.
+    """
+    if not _metrics_enabled():
+        return
+    database_queries_total.labels(operation=operation, table=table).inc()
+    database_query_duration_seconds.labels(operation=operation, table=table).observe(
+        duration_seconds
+    )
+
+
+def set_database_pool_metrics(pool_size: int, checked_out: int) -> None:
+    """Update database connection pool gauges.
+
+    Args:
+        pool_size: Total pool size.
+        checked_out: Current checked out connections.
+    """
+    if not _metrics_enabled():
+        return
+    database_pool_size.set(pool_size)
+    database_pool_checked_out.set(checked_out)

--- a/app/observability/tracing.py
+++ b/app/observability/tracing.py
@@ -1,0 +1,187 @@
+"""OpenTelemetry tracing configuration and helpers."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from contextlib import contextmanager
+from functools import wraps
+from typing import Any
+
+from opentelemetry import trace
+from opentelemetry.exporter.jaeger.thrift import JaegerExporter
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor, ConsoleSpanExporter
+from opentelemetry.sdk.trace.sampling import ParentBased, TraceIdRatioBased
+from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
+from opentelemetry.instrumentation.sqlalchemy import SQLAlchemyInstrumentor
+
+_tracing_configured = False
+
+
+def configure_tracing(
+    service_name: str,
+    jaeger_endpoint: str,
+    enable_console_export: bool,
+    *,
+    exporter_type: str = "jaeger",
+    sample_rate: float = 1.0,
+) -> None:
+    """Configure OpenTelemetry tracing.
+
+    Args:
+        service_name: Service name for tracing.
+        jaeger_endpoint: Jaeger collector endpoint or OTLP endpoint.
+        enable_console_export: Enable console span export.
+        exporter_type: Exporter type (jaeger/otlp/console).
+        sample_rate: Trace sample rate (0.0-1.0).
+    """
+    global _tracing_configured
+    if _tracing_configured:
+        return
+
+    resource = Resource.create({"service.name": service_name})
+    tracer_provider = TracerProvider(
+        resource=resource,
+        sampler=ParentBased(TraceIdRatioBased(sample_rate)),
+    )
+
+    if exporter_type == "otlp":
+        exporter = OTLPSpanExporter(endpoint=jaeger_endpoint)
+        tracer_provider.add_span_processor(BatchSpanProcessor(exporter))
+    elif exporter_type == "console":
+        tracer_provider.add_span_processor(BatchSpanProcessor(ConsoleSpanExporter()))
+    else:
+        exporter = JaegerExporter(collector_endpoint=jaeger_endpoint)
+        tracer_provider.add_span_processor(BatchSpanProcessor(exporter))
+
+    if enable_console_export and exporter_type != "console":
+        tracer_provider.add_span_processor(BatchSpanProcessor(ConsoleSpanExporter()))
+
+    trace.set_tracer_provider(tracer_provider)
+    _tracing_configured = True
+
+
+def instrument_fastapi(app: Any) -> None:
+    """Enable FastAPI auto-instrumentation.
+
+    Args:
+        app: FastAPI application instance.
+    """
+    FastAPIInstrumentor.instrument_app(app)
+
+
+def instrument_sqlalchemy(engine: Any) -> None:
+    """Enable SQLAlchemy auto-instrumentation.
+
+    Args:
+        engine: SQLAlchemy engine instance.
+    """
+    SQLAlchemyInstrumentor().instrument(engine=engine)
+
+
+def shutdown_tracing() -> None:
+    """Flush and shutdown tracing provider."""
+    provider = trace.get_tracer_provider()
+    if hasattr(provider, "shutdown"):
+        provider.shutdown()
+
+
+def get_tracer(name: str) -> trace.Tracer:
+    """Get a tracer instance for a module.
+
+    Args:
+        name: Module name.
+
+    Returns:
+        Tracer instance.
+    """
+    return trace.get_tracer(name)
+
+
+def trace_async_function(
+    span_name: str,
+    attributes: dict[str, Any] | None = None,
+) -> Callable[[Callable[..., Awaitable[Any]]], Callable[..., Awaitable[Any]]]:
+    """Decorator to trace async functions.
+
+    Args:
+        span_name: Span name.
+        attributes: Span attributes.
+
+    Returns:
+        Decorated async function.
+    """
+    def decorator(func: Callable[..., Awaitable[Any]]) -> Callable[..., Awaitable[Any]]:
+        @wraps(func)
+        async def wrapper(*args: Any, **kwargs: Any) -> Any:
+            tracer = get_tracer(func.__module__)
+            with tracer.start_as_current_span(span_name) as span:
+                if attributes:
+                    for key, value in attributes.items():
+                        span.set_attribute(key, value)
+                return await func(*args, **kwargs)
+
+        return wrapper
+
+    return decorator
+
+
+@contextmanager
+def trace_context_manager(
+    span_name: str,
+    attributes: dict[str, Any] | None = None,
+) -> Any:
+    """Context manager for manual spans.
+
+    Args:
+        span_name: Span name.
+        attributes: Span attributes.
+
+    Yields:
+        Current span.
+    """
+    tracer = get_tracer(__name__)
+    with tracer.start_as_current_span(span_name) as span:
+        if attributes:
+            for key, value in attributes.items():
+                span.set_attribute(key, value)
+        yield span
+
+
+def add_span_attributes(**kwargs: Any) -> None:
+    """Add attributes to the current span."""
+    span = trace.get_current_span()
+    if not span.is_recording():
+        return
+    for key, value in kwargs.items():
+        span.set_attribute(key, value)
+
+
+def add_span_event(name: str, attributes: dict[str, Any] | None = None) -> None:
+    """Add an event to the current span.
+
+    Args:
+        name: Event name.
+        attributes: Event attributes.
+    """
+    span = trace.get_current_span()
+    if not span.is_recording():
+        return
+    span.add_event(name, attributes=attributes or {})
+
+
+def get_current_trace_id() -> str | None:
+    """Get the current trace ID for log correlation.
+
+    Returns:
+        Trace ID hex string if present.
+    """
+    span = trace.get_current_span()
+    if not span.is_recording():
+        return None
+    ctx = span.get_span_context()
+    if not ctx or not ctx.trace_id:
+        return None
+    return format(ctx.trace_id, "032x")

--- a/app/rag/pipeline.py
+++ b/app/rag/pipeline.py
@@ -1,6 +1,7 @@
 """Async RAG pipeline using LangChain Expression Language (LCEL)."""
 
 import asyncio
+import time
 from typing import Any
 
 from langchain_community.chat_models import ChatOllama
@@ -18,6 +19,12 @@ from app.cache.redis_cache import compute_cache_key, get_redis_client
 from app.core.config import settings
 from app.core.logging import get_logger, log_cache_operation, log_generation, log_retrieval
 from app.embeddings.huggingface_tei import HuggingFaceTEIEmbedder
+from app.observability.metrics import (
+    record_cache_operation,
+    record_embedding,
+    record_rag_query,
+)
+from app.observability.tracing import add_span_attributes, add_span_event, trace_context_manager
 from app.rag.prompts.qa import QA_PROMPT_V1
 from app.rag.retrieval import retrieve_chunks
 from app.services.exceptions import (
@@ -59,36 +66,59 @@ class RAGPipeline:
         self, db: AsyncSession, query: str, collection_name: str, where: dict[str, Any] | None
     ) -> dict[str, Any]:
         """Retrieve chunks and format context."""
-        import time
-        start = time.time()
-        
-        # Embed query (async with internal caching)
-        try:
-            query_embedding = await self.embedder.embed_query(query)
-        except Exception as exc:
-            raise EmbeddingError(
-                message="Failed to generate query embedding",
-                provider="huggingface_tei",
-                **get_request_context_data(),
-            ) from exc
-        
-        # Retrieve chunks
-        try:
-            chunks = await retrieve_chunks(
-                db=db,
-                embedding=query_embedding,
-                collection_name=collection_name,
-                top_k=self.top_k,
-                where=where,
-            )
-        except Exception as exc:
-            raise VectorStoreError(
-                message="Failed to retrieve chunks from vector store",
-                operation="query",
-                **get_request_context_data(),
-            ) from exc
-        
-        retrieval_time_ms = (time.time() - start) * 1000
+        retrieval_start = time.perf_counter()
+
+        with trace_context_manager(
+            "rag.retrieval",
+            {
+                "collection_name": collection_name,
+                "top_k": self.top_k,
+                "query": query[:200],
+            },
+        ):
+            # Embed query (async with internal caching)
+            try:
+                with trace_context_manager(
+                    "rag.embed_query",
+                    {"provider": "huggingface_tei", "mode": "query"},
+                ):
+                    embed_start = time.perf_counter()
+                    query_embedding = await self.embedder.embed_query(query)
+                    embed_duration = time.perf_counter() - embed_start
+                    record_embedding(
+                        provider="huggingface_tei",
+                        mode="query",
+                        duration_seconds=embed_duration,
+                        batch_size=1,
+                    )
+            except Exception as exc:
+                raise EmbeddingError(
+                    message="Failed to generate query embedding",
+                    provider="huggingface_tei",
+                    **get_request_context_data(),
+                ) from exc
+
+            # Retrieve chunks
+            try:
+                with trace_context_manager(
+                    "rag.vector_search",
+                    {"collection_name": collection_name},
+                ):
+                    chunks = await retrieve_chunks(
+                        db=db,
+                        embedding=query_embedding,
+                        collection_name=collection_name,
+                        top_k=self.top_k,
+                        where=where,
+                    )
+            except Exception as exc:
+                raise VectorStoreError(
+                    message="Failed to retrieve chunks from vector store",
+                    operation="query",
+                    **get_request_context_data(),
+                ) from exc
+
+        retrieval_time_ms = (time.perf_counter() - retrieval_start) * 1000
         
         # Log retrieval metrics
         top_score = chunks[0]["score"] if chunks else None
@@ -109,6 +139,7 @@ class RAGPipeline:
         return {
             "context": context,
             "chunks": chunks,
+            "retrieval_time_seconds": retrieval_time_ms / 1000,
         }
 
     @retry(
@@ -118,81 +149,95 @@ class RAGPipeline:
     )
     async def _generate_answer(
         self, context: str, question: str
-    ) -> str:
+    ) -> tuple[str, float]:
         """Generate answer with retry logic, timeout, and LLM response caching."""
-        import time
-
-        # ---- LLM cache lookup ----
-        cache_key = f"llm:{settings.OLLAMA_MODEL}:{compute_cache_key(context, question, settings.OLLAMA_MODEL, settings.OLLAMA_TEMPERATURE)}"
-
-        if settings.REDIS_ENABLED:
-            redis_client = await get_redis_client()
-            cache_start = time.time()
-            cached = await redis_client.get(cache_key)
-            cache_elapsed = (time.time() - cache_start) * 1000
-
-            if cached is not None:
-                log_cache_operation(logger, "hit", "llm", cache_key, cache_elapsed)
-                return cached
-
-            log_cache_operation(logger, "miss", "llm", cache_key, cache_elapsed)
-
-        # ---- LLM generation ----
-        start = time.time()
-
-        # Build LCEL chain
-        chain = (
-            RunnableParallel(
-                context=RunnablePassthrough(),
-                question=RunnablePassthrough(),
-            )
-            | QA_PROMPT_V1
-            | self.llm
-            | StrOutputParser()
+        cache_key = (
+            f"llm:{settings.OLLAMA_MODEL}:"
+            f"{compute_cache_key(context, question, settings.OLLAMA_MODEL, settings.OLLAMA_TEMPERATURE)}"
         )
 
-        # Invoke with timeout
-        try:
-            response = await asyncio.wait_for(
-                chain.ainvoke({"context": context, "question": question}),
-                timeout=settings.LLM_TIMEOUT,
+        with trace_context_manager(
+            "rag.generation",
+            {
+                "model": settings.OLLAMA_MODEL,
+                "temperature": settings.OLLAMA_TEMPERATURE,
+                "context_length": len(context),
+            },
+        ):
+            # ---- LLM cache lookup ----
+            if settings.REDIS_ENABLED:
+                redis_client = await get_redis_client()
+                cache_start = time.perf_counter()
+                cached = await redis_client.get(cache_key)
+                cache_elapsed = time.perf_counter() - cache_start
+
+                if cached is not None:
+                    log_cache_operation(logger, "hit", "llm", cache_key, cache_elapsed * 1000)
+                    record_cache_operation("get", "llm", cache_elapsed, True)
+                    add_span_event("cache.hit", {"cache_type": "llm"})
+                    return cached, 0.0
+
+                log_cache_operation(logger, "miss", "llm", cache_key, cache_elapsed * 1000)
+                record_cache_operation("get", "llm", cache_elapsed, False)
+                add_span_event("cache.miss", {"cache_type": "llm"})
+
+            # ---- LLM generation ----
+            start = time.perf_counter()
+
+            # Build LCEL chain
+            chain = (
+                RunnableParallel(
+                    context=RunnablePassthrough(),
+                    question=RunnablePassthrough(),
+                )
+                | QA_PROMPT_V1
+                | self.llm
+                | StrOutputParser()
             )
-        except asyncio.TimeoutError as exc:
-            logger.error(
-                "LLM call timed out",
-                timeout=settings.LLM_TIMEOUT,
-                question=question[:100],
+
+            # Invoke with timeout
+            try:
+                with trace_context_manager("rag.llm_invoke"):
+                    response = await asyncio.wait_for(
+                        chain.ainvoke({"context": context, "question": question}),
+                        timeout=settings.LLM_TIMEOUT,
+                    )
+            except asyncio.TimeoutError as exc:
+                logger.error(
+                    "LLM call timed out",
+                    timeout=settings.LLM_TIMEOUT,
+                    question=question[:100],
+                )
+                raise LLMError(
+                    message=f"LLM response timed out after {settings.LLM_TIMEOUT}s",
+                    model=settings.OLLAMA_MODEL,
+                    **get_request_context_data(),
+                ) from exc
+            except Exception as exc:
+                raise LLMError(
+                    message="Failed to generate answer from LLM",
+                    model=settings.OLLAMA_MODEL,
+                    **get_request_context_data(),
+                ) from exc
+
+            generation_time_seconds = time.perf_counter() - start
+
+            # Log generation metrics
+            log_generation(
+                logger,
+                query=question,
+                response_length=len(response),
+                tokens_used=None,  # Ollama doesn't provide token count easily
+                generation_time_ms=generation_time_seconds * 1000,
             )
-            raise LLMError(
-                message=f"LLM response timed out after {settings.LLM_TIMEOUT}s",
-                model=settings.OLLAMA_MODEL,
-                **get_request_context_data(),
-            ) from exc
-        except Exception as exc:
-            raise LLMError(
-                message="Failed to generate answer from LLM",
-                model=settings.OLLAMA_MODEL,
-                **get_request_context_data(),
-            ) from exc
 
-        generation_time_ms = (time.time() - start) * 1000
+            answer = response.strip()
 
-        # Log generation metrics
-        log_generation(
-            logger,
-            query=question,
-            response_length=len(response),
-            tokens_used=None,  # Ollama doesn't provide token count easily
-            generation_time_ms=generation_time_ms,
-        )
+            # ---- Store in cache ----
+            if settings.REDIS_ENABLED:
+                await redis_client.set(cache_key, answer, ttl=settings.CACHE_TTL_LLM)
 
-        answer = response.strip()
-
-        # ---- Store in cache ----
-        if settings.REDIS_ENABLED:
-            await redis_client.set(cache_key, answer, ttl=settings.CACHE_TTL_LLM)
-
-        return answer
+            return answer, generation_time_seconds
 
     async def query(
         self,
@@ -212,35 +257,63 @@ class RAGPipeline:
         Returns:
             Dictionary with 'answer' and 'sources' keys.
         """
-        # Retrieve and format context
-        retrieval_result = await self._retrieve_and_format(
-            db, question, collection_name, where
-        )
-        
-        if not retrieval_result["chunks"]:
-            logger.info("No chunks found for query", question=question[:100])
-            return {
-                "answer": "I don't know. No relevant information was found.",
-                "sources": [],
-            }
-        
-        # Generate answer
-        answer = await self._generate_answer(
-            retrieval_result["context"],
-            question,
-        )
-        
-        # Format sources
-        sources = [
+        query_start = time.perf_counter()
+        with trace_context_manager(
+            "rag.query",
             {
-                "chunk_id": chunk["id"],
-                "score": chunk["score"],
-                "metadata": chunk.get("metadata", {}),
+                "collection_name": collection_name,
+                "question": question[:200],
+            },
+        ):
+            # Retrieve and format context
+            retrieval_result = await self._retrieve_and_format(
+                db, question, collection_name, where
+            )
+
+            if not retrieval_result["chunks"]:
+                logger.info("No chunks found for query", question=question[:100])
+                record_rag_query(
+                    collection=collection_name,
+                    duration_seconds=time.perf_counter() - query_start,
+                    retrieval_seconds=retrieval_result["retrieval_time_seconds"],
+                    generation_seconds=0.0,
+                    status="empty",
+                )
+                return {
+                    "answer": "I don't know. No relevant information was found.",
+                    "sources": [],
+                }
+
+            # Generate answer
+            answer, generation_time_seconds = await self._generate_answer(
+                retrieval_result["context"],
+                question,
+            )
+
+            # Format sources
+            sources = [
+                {
+                    "chunk_id": chunk["id"],
+                    "score": chunk["score"],
+                    "metadata": chunk.get("metadata", {}),
+                }
+                for chunk in retrieval_result["chunks"]
+            ]
+
+            total_duration = time.perf_counter() - query_start
+            record_rag_query(
+                collection=collection_name,
+                duration_seconds=total_duration,
+                retrieval_seconds=retrieval_result["retrieval_time_seconds"],
+                generation_seconds=generation_time_seconds,
+                status="success",
+            )
+            add_span_attributes(
+                num_sources=len(sources),
+                answer_length=len(answer),
+            )
+
+            return {
+                "answer": answer,
+                "sources": sources,
             }
-            for chunk in retrieval_result["chunks"]
-        ]
-        
-        return {
-            "answer": answer,
-            "sources": sources,
-        }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,10 @@ services:
       POSTGRES_HOST: postgres
       REDIS_HOST: redis
       OLLAMA_BASE_URL: http://host.docker.internal:11434
+      ENABLE_METRICS: "true"
+      ENABLE_TRACING: "true"
+      JAEGER_ENDPOINT: http://jaeger:14268/api/traces
+      OTEL_SERVICE_NAME: rag-researcher
     extra_hosts:
       - "host.docker.internal:host-gateway"
     depends_on:
@@ -62,6 +66,16 @@ services:
     networks:
       - postgres
     restart: unless-stopped
+
+  jaeger:
+    image: jaegertracing/all-in-one:latest
+    ports:
+      - "16686:16686"
+      - "14268:14268"
+    environment:
+      - COLLECTOR_OTLP_ENABLED=true
+    networks:
+      - postgres
 
 volumes:
   postgres:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,14 @@ dependencies = [
     "bcrypt",
     "python-jose[cryptography]",
     "redis[asyncio]>=5.0.0",
-    "structlog"
+    "structlog",
+    "prometheus-client",
+    "opentelemetry-api",
+    "opentelemetry-sdk",
+    "opentelemetry-instrumentation-fastapi",
+    "opentelemetry-instrumentation-sqlalchemy",
+    "opentelemetry-exporter-jaeger",
+    "opentelemetry-exporter-otlp"
 ]
 
 [build-system]


### PR DESCRIPTION
- Add metrics for HTTP requests, RAG queries, database queries, and cache operations
- Integrate OpenTelemetry with Jaeger for distributed tracing
- Add observability middleware and /metrics endpoint
- Include Jaeger service in docker-compose
- Update documentation with observability setup and usage